### PR TITLE
Fix string integer comparison failures using Puppet 3.7.4+

### DIFF
--- a/manifests/shm.pp
+++ b/manifests/shm.pp
@@ -13,7 +13,7 @@ class scaleio::shm (
 	    match => "^tmpfs",
 	    line => "tmpfs  /dev/shm  tmpfs defaults,size=${shm_size}  0 0",
 	} ->
-	if ($::kernelshmmax < 209715200) {
+	if ($::kernelshmmax.scanf("%i")[0] < 209715200) {
 	    exec {'set kernel shmmax' :
 	      command   => 'sysctl -p 209715200',
 	      logoutput => true,


### PR DESCRIPTION
The future parser deprecates automatic conversion of strings to integers.
https://tickets.puppetlabs.com/browse/PUP-3615
The fix is to use scanf to convert the strings to an array of integers (or in this case, 1 integer).
Tested using the EMCCODE vagrant environment.