### PR TITLE
Rspec fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,8 @@
+fixtures:
+  symlinks:
+    "scaleio": "#{source_dir}"
+  repositories:
+    "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "java": "https://github.com/puppetlabs/puppetlabs-java.git"
+    "dnsquery": "https://github.com/dalen/puppet-dnsquery.git"
+    "firewall": "https://github.com/puppetlabs/puppetlabs-firewall.git"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 files/*
 pkg/*
 *.tar.gz
+spec/fixtures/modules


### PR DESCRIPTION
Currently, the only test fails because of rspec-puppet having no fixtures.

This branch adds the fixtures and gets the test failing for the correct reasons :+1: 