### PR TITLE
Add note pointing to ScaleIO 2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ScaleIO
 
+## For a ScaleIO 2.x compatible module, use <https://github.com/cloudscaling/puppet-scaleio>.
+
 #### Table of Contents
 
 1. [Overview](#overview)


### PR DESCRIPTION
I already updated the repo description, and this PR makes the README have a link to the 2.0 module in quite large text.  cc/ @clintonskitson 